### PR TITLE
Improve packet handling and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ Right now the “-h” of the program looks like this:
 $ ./mcod -h
 Usage of ./mcod:
   -backend="localhost:25567": The IP address that the MC server listens on when it's online
-  -cachebanner=true: disable this if in the future they change the handshake proto
   -listen=":25565": The port / IP combo you want to listen on
-  -strict=false: Only allow requests that pass a set of rules to connect
 ```
 
-By default it will cache the banners, However. It’s worth noting that if you want to use this for other games, you will want to disable that and also alter the StartServer and StopServer scripts.
+Please note that mcod will only work on Minecraft servers that are running version 1.7 or higher, because of the way how the current network protocols are set up. It's possible that this protocol gets changed in newer Minecraft versions. If that happens, the code has to be updated to reflect the changes. It’s also worth noting that if you want to use this for other games, you have to change the code where the Minecraft protocols are used and also alter the StartServer and StopServer scripts.
 
 In addition, this software currently assumes that it will be ran on its own user. Don’t run this program on the same user as other java apps. Since by default the StopServer script kills al java applications running.
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"net"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -16,9 +19,8 @@ type GlobalState struct {
 	Lock           sync.Mutex
 	UsersConnected int
 	CachedBanner   []byte
+	ServerList     map[string]interface{}
 	BackendHost    *string
-	EnableCache    *bool
-	EnableStrict   *bool
 }
 
 var GState GlobalState
@@ -26,13 +28,10 @@ var GState GlobalState
 func main() {
 	GState = GlobalState{}
 	GState.EndServerState = "Offline"
-	GState.EnableCache = flag.Bool("cachebanner", true, "disable this if in the future they change the handshake proto")
 	listenport := flag.String("listen", ":25565", "The port / IP combo you want to listen on")
 	GState.BackendHost = flag.String("backend", "localhost:25567", "The IP address that the MC server listens on when it's online")
-	GState.EnableStrict = flag.Bool("strict", false, "Only allow requests that pass a set of rules to connect")
 	flag.Parse()
 
-	KillTimer(true)
 	lis, err := net.Listen("tcp", *listenport)
 	LazyHandle(err)
 
@@ -47,88 +46,200 @@ func main() {
 }
 
 func HandleConnection(con net.Conn) {
-	// Check if we can go into cache logic for the server banners
-	vhost_chunk := make([]byte, 1024)
-	vhost_len := 0
 	defer con.Close()
+	packet_id := uint(0)
+	data := []byte{}
+	packet := []byte{}
+	r := bufio.NewReader(con)
 
-	if *GState.EnableCache {
-		vhost_len, _ = con.Read(vhost_chunk)
+	// Read incoming packet
+	packet_id, data, packet = ReadPacket(r)
+	i := 0
 
-		if vhost_chunk[vhost_len-3] == 0x01 && vhost_chunk[vhost_len-1] == 0x00 {
-			err := HandleCachedBanner(con, vhost_chunk[:vhost_len], false)
-			if err == nil {
-				return
-			}
-		} else if vhost_chunk[vhost_len-1] == 0x01 {
-			ping_chunk := make([]byte, 1024)
-			con.Read(ping_chunk) // Begone
-			err := HandleCachedBanner(con, vhost_chunk[:vhost_len], true)
-			if err == nil {
-				return
-			}
-		} else {
-			if *GState.EnableStrict && !((vhost_chunk[vhost_len-3] == 0x02 && vhost_chunk[vhost_len-1] == 0x00) || vhost_chunk[vhost_len-1] == 0x02) {
-				log.Printf("Rejecting invalid looking request. Packet was %x", vhost_chunk[:vhost_len])
-				return
-			} else {
-				log.Printf("Uncacheable request passing to server... Last byte: %x", vhost_chunk[vhost_len-1])
-			}
-		}
-	}
+	if packet_id == 0x00 {
+		// Handshake
+		log.Printf("<%s> Received handshake", con.RemoteAddr().String())
 
-	log.Printf("New Player Joining...")
-
-	if GState.EndServerState == "Offline" {
-		GState.Lock.Lock()
-		if GState.EndServerState == "Offline" {
-
-			GState.EndServerState = "Starting"
-			RunStartScript()
-
-		}
-		GState.Lock.Unlock()
-
-	}
-	if GState.EndServerState == "Starting" {
-		log.Printf("Player is waiting for server to start...")
-		GState.Lock.Lock()
-		GState.Lock.Unlock()
-	}
-
-	Scon, err := net.Dial("tcp", *GState.BackendHost)
-	if err != nil {
-		con.Close()
-		GState.EndServerState = "Offline"
-		return
-	}
-
-	if *GState.EnableCache {
-		_, err = Scon.Write(vhost_chunk[0:vhost_len])
-		if err != nil {
-			log.Printf("Error in pulling connection online to backend, error was: %s", err)
-			con.Close()
+		// Protocol version
+		_, bytes_read := ReadVarint(data[i:])
+		if bytes_read <= 0 {
+			log.Printf("<%s> An error occured when reading protocol version of handshake packet: %d", con.RemoteAddr().String(), bytes_read)
 			return
 		}
-	}
+		i += bytes_read
 
-	GState.UsersConnected++
-	log.Printf("There are now %d people connected", GState.UsersConnected)
-	go io.Copy(Scon, con)
-	io.Copy(con, Scon)
-	GState.UsersConnected--
-	log.Printf("There are now %d people connected", GState.UsersConnected)
+		// Address
+		_, bytes_read = ReadString(data[i:])
+		if bytes_read <= 0 {
+			log.Printf("<%s> An error occured when reading server address of handshake packet: %d", con.RemoteAddr().String(), bytes_read)
+			return
+		}
+		i += bytes_read
 
-	if GState.UsersConnected == 0 {
-		// Set a reminder to check in 1 min and then shut the server down
-		go KillTimer(false)
+		// Port
+		//port := binary.BigEndian.Uint16(data[i:i + 2])
+		i += 2
+
+		// Next state
+		next_state, bytes_read := ReadVarint(data[i:])
+		if (bytes_read <= 0) {
+			log.Printf("<%s> An error occured when reading next state of handshake packet: %d", con.RemoteAddr().String(), bytes_read)
+			return
+		}
+
+		if next_state == 0x01 {
+			// Server list request
+			log.Printf("<%s> Received server list request", con.RemoteAddr().String())
+
+			// Consume request packet
+			packet_id2, data2, _ := ReadPacket(r)
+			if packet_id2 == 0x00 && len(data2) == 0 {
+				log.Printf("<%s> Received request", con.RemoteAddr().String())
+
+				// Generating response
+				server_list_json := GetServerList()
+				response := MakePacket(0x00, MakeString(server_list_json))
+				con.Write(response)
+				log.Printf("<%s> Sent response", con.RemoteAddr().String())
+			}
+
+			// Prepare for ping request
+			packet_id2, _, packet2 := ReadPacket(r)
+			i = 0
+			if packet_id2 == 0x01 {
+				// Ping
+				log.Printf("<%s> Received ping", con.RemoteAddr().String())
+
+				// Send same packet back to the client
+				con.Write(packet2)
+				log.Printf("<%s> Sent pong", con.RemoteAddr().String())
+
+				// Done
+				return
+			}
+		} else if next_state == 0x02 {
+			// Login request
+			log.Printf("<%s> Received login request", con.RemoteAddr().String())
+
+			if GState.EndServerState == "Offline" {
+				GState.Lock.Lock()
+				if GState.EndServerState == "Offline" {
+					GState.EndServerState = "Starting"
+					go RunStartScript()
+					log.Printf("<%s> Server starting, aborting request", con.RemoteAddr().String())
+					con.Write(MakePacket(0x00, MakeString("\"Server is now starting up! Please wait a few minutes before reconnecting.\"")))
+				}
+				GState.Lock.Unlock()
+			}
+			if GState.EndServerState == "Starting" {
+				log.Printf("<%s> Server is still starting, aborting request", con.RemoteAddr().String())
+				con.Write(MakePacket(0x00, MakeString("\"Server is still starting! Please wait before reconnecting.\"")))
+				return
+			}
+
+			// Proceed to relay packets to the real server
+			log.Printf("<%s> Player logging in", con.RemoteAddr().String())
+			Scon, err := net.Dial("tcp", *GState.BackendHost)
+			defer Scon.Close()
+
+			if err != nil {
+				GState.EndServerState = "Offline"
+				log.Printf("<%s> Error while connecting to the backend server: %s", con.RemoteAddr().String(), err)
+				con.Write(MakePacket(0x00, MakeString("\"Could not connect to the backend server. Please notify the server administrator.\"")))
+				return
+			}
+
+			_, err = Scon.Write(packet)
+			if err != nil {
+				log.Printf("<%s> Error while relaying data to the backend server: %s", con.RemoteAddr().String(), err)
+				con.Write(MakePacket(0x00, MakeString("\"Could not relay data to the backend server. Please notify the server administrator.\"")))
+				return
+			}
+
+			GState.UsersConnected++
+			log.Printf("There are now %d people connected", GState.UsersConnected)
+			go io.Copy(Scon, con)
+			io.Copy(con, Scon)
+			GState.UsersConnected--
+			log.Printf("There are now %d people connected", GState.UsersConnected)
+
+			if GState.UsersConnected == 0 {
+				// Set a reminder to check in 1 min and then shut the server down
+				go KillTimer(1)
+			}
+		}
 	}
 }
 
-func KillTimer(force bool) {
-	if !force {
-		time.Sleep(time.Minute)
+func ReadPacket(r *bufio.Reader) (uint, []byte, []byte) {
+	length, err := binary.ReadUvarint(r)
+	if err != nil {
+		if err != io.EOF {
+			log.Printf("An error occured when reading packet length: %d", err)
+		}
+		return 0, nil, nil
 	}
+	packet := make([]byte, length)
+	bytes_read, _ := io.ReadFull(r, packet)
+
+	if int(length) != bytes_read {
+		full_packet := append(MakeVarint(int(length)), packet...)
+		log.Printf("Received unknown packet, proceeding as legacy packet 0x%x", length)
+		return uint(length), packet, full_packet
+	}
+
+	// Read packet id
+	packet_id, bytes_read := ReadVarint(packet)
+	if bytes_read <= 0 {
+		log.Printf("An error occured when reading packet id of packet: %d", bytes_read)
+		return 0, nil, nil
+	}
+	i := bytes_read
+
+	if length == 0 {
+		return uint(packet_id), []byte{}, append(MakeVarint(int(length)), packet...)
+	} else {
+		return uint(packet_id), packet[i:], append(MakeVarint(int(length)), packet...)
+	}
+}
+
+func MakePacket(packet_id int, data []byte) ([]byte) {
+	packet := append(MakeVarint(packet_id), data...)
+	return append(MakeVarint(len(packet)), packet...)
+}
+
+func ReadVarint(data []byte) (int, int) {
+	value, bytes_read := binary.Uvarint(data)
+	if bytes_read <= 0 {
+		log.Printf("An error occured while reading varint: %d", bytes_read)
+		return 0, bytes_read
+	}
+	return int(value), bytes_read
+}
+
+func MakeVarint(value int) ([]byte) {
+	temp := make([]byte, 10)
+	bytes_written := binary.PutUvarint(temp, uint64(value))
+	return temp[:bytes_written]
+}
+
+func ReadString(data []byte) (string, int) {
+	length, bytes_read := ReadVarint(data)
+	if bytes_read <= 0 {
+		log.Printf("An error occured while reading string: %d", bytes_read)
+		return "", bytes_read
+	}
+	return string(data[bytes_read:bytes_read + length]), bytes_read + length
+}
+
+func MakeString(str string) ([]byte) {
+	data := []byte(str)
+	return append(MakeVarint(len(data)), data...)
+}
+
+func KillTimer(minutes int) {
+	time.Sleep(time.Duration(minutes) * time.Minute)
+
 	if GState.UsersConnected == 0 {
 		log.Printf("Shutting down server due to idle...")
 		cmd := exec.Command("./StopServer")
@@ -154,6 +265,9 @@ func RunStartScript() {
 	err = cmd.Wait()
 	log.Printf("Server online")
 	GState.EndServerState = "Online"
+
+	// Set command to shut down server in 5 minutes if no one connects
+	go KillTimer(5)
 }
 
 func LazyHandle(err error) {
@@ -162,45 +276,113 @@ func LazyHandle(err error) {
 	}
 }
 
-func HandleCachedBanner(con net.Conn, vhost_chunk []byte, appendping bool) (err error) {
-	if len(GState.CachedBanner) != 0 && (GState.EndServerState == "Offline" || GState.EndServerState == "Starting") {
-		log.Println("Serving the banner from cache")
+func GetServerList() (string) {
+	if GState.ServerList == nil {
+		// Construct our placeholder server list from scratch
+		GState.ServerList = map[string]interface{} {
+			"version": map[string]interface{} {
+				"name": "unknown",
+				"protocol": 4,
+			},
+			"players": map[string]interface{} {
+				"max": 0,
+				"online": 0,
+			},
+			"description": map[string]interface{} {
+				"text": "Join to initialize description",
+			},
+		}
+	}
 
-		con.Write(GState.CachedBanner)
-		return err
+	old_motd := GetServerDescription()
+
+	if GState.EndServerState == "Offline" {
+		SetServerDescription(old_motd + " (idle)")
+	} else if GState.EndServerState == "Starting" {
+		SetServerDescription(old_motd + " (starting)")
 	} else if GState.EndServerState == "Online" {
-		// Cache time!
-		log.Println("Pulling a new copy of the banner from the origin and caching for future use")
-
-		Scon, err := net.Dial("tcp", *GState.BackendHost)
+		// Server is online
+		scon, err := net.Dial("tcp", *GState.BackendHost)
 		LazyHandle(err)
+		r := bufio.NewReader(scon)
+		defer scon.Close()
 
-		defer Scon.Close()
 		if err != nil {
 			GState.EndServerState = "Offline"
-			return err
-		}
+		} else {
+			// Create our own handshake to request the real server list
+			// Protocol version
+			handshake := MakeVarint(4)
 
-		if appendping {
-			vhost_chunk = append(vhost_chunk, 0x01)
-			vhost_chunk = append(vhost_chunk, 0x00)
-		}
+			// Address
+			handshake = append(handshake, MakeString("localhost")...)
 
-		_, err = Scon.Write(vhost_chunk)
-		if err != nil {
-			log.Printf("Error in pulling a cached banner. Error was: %s", err)
-			return err
+			// Port
+			_, port_str, _ := net.SplitHostPort(*GState.BackendHost)
+			port, _ := strconv.Atoi(port_str)
+			temp_port := make([]byte, 2)
+			binary.BigEndian.PutUint16(temp_port, uint16(port))
+			handshake = append(handshake, temp_port...)
+
+			// Next state
+			handshake = append(handshake, MakeVarint(1)...)
+
+			// Make packet and send handshake and request
+			handshake = MakePacket(0x00, handshake)
+			scon.Write(handshake)
+
+			request := MakePacket(0x00, nil)
+			scon.Write(request)
+
+			log.Println("Sent server list request to server")
+
+			// Receive data
+			_, data, _ := ReadPacket(r)
+
+			server_list_json, _ := ReadString(data)
+			var json_data interface{}
+			json.Unmarshal([]byte(server_list_json), &json_data)
+
+			// Check if it's a valid server list, otherwise we assume the server is still starting
+			switch json_data.(type) {
+			case map[string]interface{}:
+				// Appears to be valid, update server description
+				log.Println("Received server list response from server")
+				GState.ServerList = json_data.(map[string]interface{})
+				return server_list_json
+			default:
+				// Not a valid response, server is not ready yet
+				SetServerDescription(old_motd + " (readying up)")
+			}
 		}
-		banner_chunk := make([]byte, 25565)
-		read, err := Scon.Read(banner_chunk)
-		if err != nil {
-			log.Printf("Error in pulling a cached banner. Error was: %s", err)
-			return err
-		}
-		GState.CachedBanner = banner_chunk[0:read]
-		con.Write(banner_chunk[0:read])
-		return err
-	} else {
-		return fmt.Errorf("Not cached")
+	}
+
+	server_list_json, _ := json.Marshal(GState.ServerList)
+
+	// Reset our description again
+	SetServerDescription(old_motd)
+
+	return string(server_list_json)
+}
+
+func GetServerDescription() (string) {
+	switch GState.ServerList["description"].(type) {
+	case string:
+		// In case the description is a string directly
+		return GState.ServerList["description"].(string)
+	default:
+		// In other cases description should be an object that contains text
+		return GState.ServerList["description"].(map[string]interface{})["text"].(string)
+	}
+}
+
+func SetServerDescription(text string) {
+	switch GState.ServerList["description"].(type) {
+	case string:
+		// In case the description is a string directly
+		GState.ServerList["description"] = text
+	default:
+		// In other cases description should be an object that contains text
+		GState.ServerList["description"].(map[string]interface{})["text"] = text
 	}
 }


### PR DESCRIPTION
As promised per email, these are the changes I made that you can merge:
- Improved packet handling
- Shows server status in the MotD (e.g. idle, starting)
- Supports ping packets
- Refuses player logins when the server is not ready yet, instead of timing out after a certain amount of time (it also shows why the connection was refused)
- Improved logging
- I removed the configuration of banner caching and strict mode, since it's now baked in (this does make it incompatible with Minecraft versions before 1.7 and other games without code changes, I have made a note of that in the readme file)

It can still be improved of course. If there's anything you want me to do in this PR, let me know.
